### PR TITLE
deprecated mumbai, updated to amoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 > [!Important]  
-> This repository is referencing the `mumbai` chain.
+> This repository is using the `Polygon Amoy Testnet` chain.
 > 
-> `Mumbai` [is deprecated since 08/04/2024](https://blog.thirdweb.com/deprecation-of-mumbai-testnet/), meaning the code in this repository will no longer work out of the box.
+> Previously, this repository referenced the `Mumbai` testnet which [was deprecated since 08/04/2024](https://blog.thirdweb.com/deprecation-of-mumbai-testnet/).
 >
-> You can still use this repository, however you will have to switch any references to `mumbai` to another chain.
+> The code has been updated to use the Polygon Amoy Testnet (Chain ID: 80002) instead.
 
 # ERC721 Drop Claim Page
 
@@ -60,6 +60,24 @@ export const chainConst = Sepolia;
 
 If your chain is not included in the `@thirdweb-dev/chains` package, you can provide the chain information yourself by creating an object as mentioned [here](https://portal.thirdweb.com/react/react.thirdwebprovider#custom-evm-chains)
 
+#### Example for Polygon Amoy Testnet
+
+```ts
+export const chainConst = {
+  chainId: 80002,
+  rpc: ["https://80002.rpc.thirdweb.com"],
+  nativeCurrency: {
+    name: "MATIC",
+    symbol: "MATIC",
+    decimals: 18,
+  },
+  shortName: "amoy",
+  slug: "polygon-amoy",
+  testnet: true,
+  chain: "Polygon",
+  name: "Polygon Amoy Testnet",
+};
+```
 
 ### 3. Customize the Styling
 

--- a/src/consts/parameters.ts
+++ b/src/consts/parameters.ts
@@ -6,7 +6,20 @@ export const contractConst = "0x436492DBc2E30E56FaC8F2297BD1964833c0687d";
 
 // The name of the chain your contract is deployed to.
 // Refer to README.md on how to specify the chain name.
-export const chainConst = "mumbai";
+export const chainConst = {
+  chainId: 80002,
+  rpc: ["https://80002.rpc.thirdweb.com"],
+  nativeCurrency: {
+    name: "MATIC",
+    symbol: "MATIC",
+    decimals: 18,
+  },
+  shortName: "amoy",
+  slug: "polygon-amoy",
+  testnet: true,
+  chain: "Polygon",
+  name: "Polygon Amoy Testnet",
+};
 
 // It is IMPORTANT to provide your own API key to use the thirdweb SDK and infrastructure.
 // Please ensure that you define the correct domain for your API key from the API settings page.


### PR DESCRIPTION
This repository using the `Mumbai` testnet which [was deprecated since 08/04/2024](https://blog.thirdweb.com/deprecation-of-mumbai-testnet/).

Updated Chain Configuration:

```
export const chainConst = {
  chainId: 80002,
  rpc: ["https://80002.rpc.thirdweb.com"],
  nativeCurrency: {
    name: "MATIC",
    symbol: "MATIC",
    decimals: 18,
  },
  chain: "Polygon",
  shortName: "amoy",
  name: "Polygon Amoy Testnet",
  testnet: true,
};
```
